### PR TITLE
use Temurin JDK

### DIFF
--- a/.github/workflows/gradle-publish-main-release.yml
+++ b/.github/workflows/gradle-publish-main-release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Build with Gradle
         run: ./gradlew distZip


### PR DESCRIPTION

AdoptOpenJDK is obsolete. Use Temurin instead.

