### PR TITLE
Add separate option for setting rate during populate phase

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/commands/Run.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/commands/Run.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easycassstress.commands
 import com.beust.jcommander.DynamicParameter
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
+import com.beust.jcommander.ParametersDelegate
 import com.beust.jcommander.converters.IParameterSplitter
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.ScheduledReporter
@@ -15,10 +16,11 @@ import com.google.common.util.concurrent.RateLimiter
 import com.rustyrazorblade.easycassstress.*
 import com.rustyrazorblade.easycassstress.Metrics
 import com.rustyrazorblade.easycassstress.converters.ConsistencyLevelConverter
-import  com.rustyrazorblade.easycassstress.converters.HumanReadableConverter
-import  com.rustyrazorblade.easycassstress.converters.HumanReadableTimeConverter
-import  com.rustyrazorblade.easycassstress.generators.ParsedFieldFunction
-import  com.rustyrazorblade.easycassstress.generators.Registry
+import com.rustyrazorblade.easycassstress.converters.HumanReadableConverter
+import com.rustyrazorblade.easycassstress.converters.HumanReadableTimeConverter
+import com.rustyrazorblade.easycassstress.delegates.PopulateOptions
+import com.rustyrazorblade.easycassstress.generators.ParsedFieldFunction
+import com.rustyrazorblade.easycassstress.generators.Registry
 import me.tongfei.progressbar.ProgressBar
 import me.tongfei.progressbar.ProgressBarStyle
 import org.apache.logging.log4j.kotlin.logger
@@ -186,8 +188,8 @@ class Run(val command: String) : IStressCommand {
     @Parameter(names = ["--hdr"], description = "Print HDR Histograms using this prefix")
     var hdrHistogramPrefix = ""
 
-    @Parameter(names = ["--populate-rate"], description = "Sets the populate rate")
-    var populateRate = rate
+    @ParametersDelegate
+    var populateRate = PopulateOptions()
 
     /**
      * Lazily generate query options
@@ -309,7 +311,7 @@ class Run(val command: String) : IStressCommand {
             // run the prepare for each
             val runners = createRunners(plugin, metrics, fieldRegistry, rateLimiter)
 
-            rateLimiter.rate = populateRate.toDouble()
+            rateLimiter.rate = populateRate.rate
 
             populateData(plugin, runners, metrics)
 

--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/delegates/PopulateOptions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/delegates/PopulateOptions.kt
@@ -1,0 +1,8 @@
+package com.rustyrazorblade.easycassstress.delegates
+
+import com.beust.jcommander.Parameter
+
+class PopulateOptions {
+    @Parameter(names = ["--populate.rate"], description = "Sets the populate rate")
+    var rate: Double = 50000.0
+}


### PR DESCRIPTION
### What does this PR do?
This PR fixes issue #13, where the application needs a separate option for setting rate during populate phase.

### How did I fix it?
I added a new option called "--populate-rate" with its value defaulting to rate. Before calling populateData, I set the rateLimiter to populateRate, and afterward, I reset the rateLimiter back to rate.