### PR TITLE
Avoid locking for SynchronizedHistogram if not needed to allow to generate more load with less hardware

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/OperationCallback.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/OperationCallback.kt
@@ -14,7 +14,8 @@ import org.apache.logging.log4j.kotlin.logger
 class OperationCallback(val context: StressContext,
                         val runner: IStressRunner,
                         val op: Operation,
-                        val paginate: Boolean = false) : FutureCallback<ResultSet> {
+                        val paginate: Boolean = false,
+                        val writeHdr: Boolean = true) : FutureCallback<ResultSet> {
 
     companion object {
         val log = logger()
@@ -41,21 +42,26 @@ class OperationCallback(val context: StressContext,
         // might extend this to select, but I can't see a reason for it now
         when (op) {
             is Operation.Mutation -> {
-                context.metrics.mutationHistogram.recordValue(time)
+                if (writeHdr) {
+                    context.metrics.mutationHistogram.recordValue(time)
+                }
                 runner.onSuccess(op, result)
             }
 
             is Operation.Deletion -> {
-                context.metrics.deleteHistogram.recordValue(time)
+                if (writeHdr) {
+                    context.metrics.deleteHistogram.recordValue(time)
+                }
             }
 
             is Operation.SelectStatement -> {
-                context.metrics.selectHistogram.recordValue(time)
+                if (writeHdr) {
+                    context.metrics.selectHistogram.recordValue(time)
+                }
             }
             is Operation.Stop -> {
                 throw OperationStopException()
             }
         }
-
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/ProfileRunner.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/ProfileRunner.kt
@@ -117,7 +117,9 @@ class ProfileRunner(val context: StressContext,
         // move the getNextOperation into the queue thing
         for (op in queue.getNextOperation()) {
             val future = context.session.executeAsync(op.bound)
-            Futures.addCallback(future, OperationCallback(context, runner, op, paginate = context.mainArguments.paginate), MoreExecutors.directExecutor())
+            Futures.addCallback(future, OperationCallback(context, runner, op,
+                paginate = context.mainArguments.paginate,
+                writeHdr = context.mainArguments.hdrHistogramPrefix != ""), MoreExecutors.directExecutor())
         }
 
     }


### PR DESCRIPTION
Profiling easy-cass-stress itself shows that locking as part of writing histogram information become a scalability blockers when increasing rate on larger machines.

The tool can generate more load with less hardware if this work is not done if not needed anyway.

We can use the same condition that is used later for reading the histogram-data
